### PR TITLE
Fix safari CORS error

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
       <a href="https://syntax.fm/">Syntax.fm RSS Feed!</a> Report it (or fix it)
       on <a href="https://github.com/rmkubik/sick-picks/issues/new"> Github!</a>
     </p>
+
+    <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=fetch"></script>
     <script src="./index.js"></script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ const rssParser = new Parser();
 
 (async () => {
   try {
-    const feed = await rssParser.parseURL("https://feed.syntax.fm/rss");
+    const feedResponse = await fetch("https://feed.syntax.fm/rss");
+    const feedString = await feedResponse.text();
+    const feed = await rssParser.parseString(feedString);
     let sickPicks = [];
     feed.items.forEach(item => {
       const sickPick = document.createElement("div");


### PR DESCRIPTION
Hello,

To fix https://github.com/rmkubik/sick-picks/issues/1, I tried to remove `User-Agent` header provided by `rss-parser` in the request (which is the problem in Safari). Seems it doesn't seem to be possible, I used fetch to retrieve the css feed.

It seems to work fine in all browsers.